### PR TITLE
#35 Implement CRUD API for Todos

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,4 @@
+DB_HOST: mysql
+DB_USER: todo_user
+DB_PASSWORD: todopassword
+DB_NAME: todo_app

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,11 @@
+const mysql = require("mysql2/promise");
+require("dotenv").config();
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
+
+module.exports = pool;

--- a/backend/index.js
+++ b/backend/index.js
@@ -4,16 +4,30 @@ const dotenv = require("dotenv");
 
 dotenv.config();
 
+const db = require("./config/db");
+const todoRoutes = require("./routes/todos");
 const app = express();
 const PORT = process.env.PORT || 8080;
 
 app.use(cors());
 app.use(express.json());
 
+app.use("/api/todos", todoRoutes);
+
+app.get("/db-check", async (req, res) => {
+  try {
+    const [rows] = await db.query("SELECT 1 + 1 AS result");
+    res.json({ dbConnection: true, result: rows[0].result });
+  } catch (err) {
+    console.error("Database connection error:", err.message);
+    res.status(500).json({ dbConnection: false, error: err.message });
+  }
+});
+
 app.get("/", (req, res) => {
   res.send("TODO App Backend is running.");
 });
 
 app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
+  console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/backend/routes/todos.js
+++ b/backend/routes/todos.js
@@ -1,0 +1,47 @@
+const express = require("express");
+const router = express.Router();
+const db = require("../config/db");
+
+router.get("/", async (req, res) => {
+  try {
+    const [rows] = await db.query("SELECT * FROM todos ORDER BY created_at DESC");
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/", async (req, res) => {
+  const { title } = req.body;
+  try {
+    const [result] = await db.query("INSERT INTO todos (title, completed) VALUES (?, ?)", [title, false]);
+    const [newTodo] = await db.query("SELECT * FROM todos WHERE id = ?", [result.insertId]);
+    res.status(201).json(newTodo[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put("/:id", async (req, res) => {
+  const { id } = req.params;
+  const { title, completed } = req.body;
+  try {
+    await db.query("UPDATE todos SET title = ?, completed = ? WHERE id = ?", [title, completed, id]);
+    const [updated] = await db.query("SELECT * FROM todos WHERE id = ?", [id]);
+    res.json(updated[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const { id } = req.params;
+  try {
+    await db.query("DELETE FROM todos WHERE id = ?", [id]);
+    res.json({ message: "Todo deleted successfully" });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   mysql:
@@ -39,7 +38,7 @@ services:
       dockerfile: Dockerfile
     container_name: frontend
     ports:
-      - "3000:3000"
+      - "3001:3000"
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
1. Run with Docker:
  - docker compose build --no-cache
  - docker compose up
-> Open Postman -> Send http://localhost:8080/db-check to check the result
2. Test API with Postman:
  - GET /api/todos` → Fetch all todos → Successful: 200 OK  
  - `POST /api/todos` → Create a new todo (JSON: `{ "title": "...", "completed": false }`) → Successful: 201 Created  
  - `PUT /api/todos/:id` → Update a todo (JSON: `{ "title": "...", "completed": true }`) → Successful: 200 OK  
  - `DELETE /api/todos/:id` → Delete a todo → Successful: 200 OK
 -> Tested with valid/invalid data and non-existing IDs to verify error handling (`400`, `404`)

Closes #35 